### PR TITLE
Repo: Use npm ci command instead of install

### DIFF
--- a/lib/repo.js
+++ b/lib/repo.js
@@ -22,7 +22,7 @@ repo = module.exports = {
 		console.log();
 
 		console.log( "Installing dependencies..." );
-		util.exec( "npm install --no-save", "Error installing dependencies." );
+		util.exec( "npm ci", "Error installing dependencies." );
 		console.log();
 	},
 
@@ -121,7 +121,7 @@ repo = module.exports = {
 			currentVersion :
 			[ major, minor, patch + 1 ].join( "." ) + "-pre";
 
-		console.log( "We are going to releease " + chalk.cyan( Release.newVersion ) + "." );
+		console.log( "We are going to release " + chalk.cyan( Release.newVersion ) + "." );
 		console.log(
 			"After the release, the version will be " +
 				chalk.cyan( Release.nextVersion ) + "."


### PR DESCRIPTION
Also, fix a small typo.

Used this on the 2.9.3 release of QUnit and it worked nicely.